### PR TITLE
fix: point chart icon at s.giantswarm.io instead of raw.githubusercontent.com

### DIFF
--- a/helm/goldilocks-app/Chart.yaml
+++ b/helm/goldilocks-app/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 appVersion: "v4.9.0"
 annotations:
   application.giantswarm.io/team: turtles
-  ui.giantswarm.io/logo: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/goldilocks/icon.png
-version: "6.3.0"
+  ui.giantswarm.io/logo: https://s.giantswarm.io/app-icons/goldilocks/1/icon_light.svg
+version: "6.3.1"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks
-icon: https://raw.githubusercontent.com/FairwindsOps/charts/master/stable/goldilocks/icon.png
+icon: https://s.giantswarm.io/app-icons/goldilocks/1/icon_light.svg
 maintainers:
   - name: giantswarm/team-turtles
     email: team-turtles@giantswarm.io

--- a/helm/goldilocks-app/Chart.yaml
+++ b/helm/goldilocks-app/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v4.9.0"
 annotations:
   application.giantswarm.io/team: turtles
   ui.giantswarm.io/logo: https://s.giantswarm.io/app-icons/goldilocks/1/icon_light.svg
-version: "6.3.1"
+version: "6.3.0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks
 name: goldilocks

--- a/helm/goldilocks-app/Chart.yaml
+++ b/helm/goldilocks-app/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 appVersion: "v4.9.0"
 annotations:
   application.giantswarm.io/team: turtles
-  ui.giantswarm.io/logo: https://s.giantswarm.io/app-icons/goldilocks/1/icon_light.svg
 version: "6.3.0"
 description: |
   A Helm chart for running Fairwinds Goldilocks. See https://github.com/FairwindsOps/goldilocks


### PR DESCRIPTION
The chart's `icon` field points at `raw.githubusercontent.com`, which isn't on Backstage's CSP `img-src` allowlist, so the icon is blocked on the catalog list page across every customer instance that has this app in its catalog.

- Sentry: [DEVPORTAL-FRONTEND-R](https://giantswarm.sentry.io/issues/DEVPORTAL-FRONTEND-R) — 168 occurrences since 2026-02-05, 8 users affected

A Giant Swarm-hosted icon already exists in `web-assets`: https://github.com/giantswarm/web-assets/blob/main/assets/app-icons/goldilocks/1/icon_light.svg. This repoints `icon` to `https://s.giantswarm.io/app-icons/goldilocks/1/icon_light.svg`.

Also removes the `ui.giantswarm.io/logo` annotation — that was for horizontally-shaped logo marks used by the legacy happa UI, not square icons, so it didn't apply here.

The chart version is left as-is — CI bumps it on release.
